### PR TITLE
Remove unused dependencies.

### DIFF
--- a/scribe-tool/index.js
+++ b/scribe-tool/index.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var async = require('async');
 var email = require('emailjs');
 var fs = require('fs')

--- a/scribe-tool/package.json
+++ b/scribe-tool/package.json
@@ -10,15 +10,10 @@
     "commander": "~1.0.0",
     "emailjs": "~0.3.3",
     "html-entities": "~1.0.10",
-    "mailparser": "~0.2.26",
-    "mime": "~1.2.7",
-    "moment": "~1.7.2",
     "twitter": "~0.2.5",
-    "underscore": "~1.5.0",
     "wporg": "~0.1.0"
   },
   "devDependencies": {
-    "prompt": "=0.2.2",
-    "sprintf": "~0.1.0"
+    "prompt": "=0.2.2"
   }
 }


### PR DESCRIPTION
- These deps are not used and yet still causing security notifications.
- This repo is not really used anymore, and if anyone hits bugs related to this change, the tooling should all be updated to more modern versions.